### PR TITLE
add cmp for gdpr

### DIFF
--- a/src/components/common/CMP.astro
+++ b/src/components/common/CMP.astro
@@ -1,0 +1,12 @@
+---
+
+---
+
+<script type="text/javascript">
+var _iub = _iub || [];
+_iub.csConfiguration = {"siteId":4039193,"cookiePolicyId":78138593,"lang":"en","storage":{"useSiteId":true}};
+</script>
+<script type="text/javascript" src="https://cs.iubenda.com/autoblocking/4039193.js"></script>
+<script type="text/javascript" src="//cdn.iubenda.com/cs/gpp/stub.js"></script>
+<script type="text/javascript" src="//cdn.iubenda.com/cs/iubenda_cs.js" charset="UTF-8" async></script>
+

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -9,6 +9,7 @@ import CustomStyles from '~/components/CustomStyles.astro';
 import ApplyColorMode from '~/components/common/ApplyColorMode.astro';
 import Metadata from '~/components/common/Metadata.astro';
 import SiteVerification from '~/components/common/SiteVerification.astro';
+import CMP from '~/components/common/CMP.astro';
 import Analytics from '~/components/common/Analytics.astro';
 import BasicScripts from '~/components/common/BasicScripts.astro';
 
@@ -34,6 +35,7 @@ const { language, textDirection } = I18N;
     <ApplyColorMode />
     <Metadata {...metadata} />
     <SiteVerification />
+    <CMP />
     <Analytics />
 
     <!-- Comment the line below to disable View Transitions -->


### PR DESCRIPTION
iubenda

Free forever plan available. Premium plans start at $5.99/month.

Pricing details
Free trial length: 90 days
Free-forever plan up to 5,000 pageviews/month
Essentials: 4.99€ / month
Advanced: 19.99€ / month
Ultimate: 79.99€ / month
Enterprise and Custom: on demand