### PR TITLE
add consent

### DIFF
--- a/public/consent_config.js
+++ b/public/consent_config.js
@@ -1,84 +1,215 @@
+// By default, Klaro will load the config from  a global "klaroConfig" variable.
+// You can change this by specifying the "data-config" attribute on your
+// script take, e.g. like this:
+// <script src="klaro.js" data-config="myConfigVariableName" />
 var klaroConfig = {
+  // With the 0.7.0 release we introduce a 'version' paramter that will make
+  // it easier for us to keep configuration files backwards-compatible in the future.
+  version: 1,
+
+  // You can customize the ID of the DIV element that Klaro will create
+  // when starting up. If undefined, Klaro will use 'klaro'.
+  elementID: 'klaro',
+
+  // You can override CSS style variables here. For IE11, Klaro will
+  // dynamically inject the variables into the CSS. If you still consider
+  // supporting IE9-10 (which you probably shouldn't) you need to use Klaro
+  // with an external stylesheet as the dynamic replacement won't work there.
+  styling: {
+    theme: ['light', 'bottom'],
+  },
+
+  // You can show a description in contextual consent overlays for store
+  // being empty. In that case the accept always button is omitted.
+  // The description contains a link for opening the consent manager.
+  showDescriptionEmptyStore: true,
+
+  // Setting this to true will keep Klaro from automatically loading itself
+  // when the page is being loaded.
+  noAutoLoad: false,
+
+  // Setting this to true will render the descriptions of the consent
+  // modal and consent notice are HTML. Use with care.
+  htmlTexts: true,
+
+  // Setting 'embedded' to true will render the Klaro modal and notice without
+  // the modal background, allowing you to e.g. embed them into a specific element
+  // of your website, such as your privacy notice.
+  embedded: false,
+
+  // You can group services by their purpose in the modal. This is advisable
+  // if you have a large number of services. Users can then enable or disable
+  // entire groups of services instead of having to enable or disable every service.
+  groupByPurpose: true,
+
+  // You can make the consent notice autofocused by enabling the following option
+  autoFocus: false,
+
+  // You can show a title in the consent notice by enabling the following option
+  showNoticeTitle: false,
+
+  // How Klaro should store the user's preferences. It can be either 'cookie'
+  // (the default) or 'localStorage'.
+  storageMethod: 'cookie',
+
+  // You can customize the name of the cookie that Klaro uses for storing
+  // user consent decisions. If undefined, Klaro will use 'klaro'.
+  cookieName: 'klaro',
+
+  // You can also set a custom expiration time for the Klaro cookie.
+  // By default, it will expire after 120 days.
+  cookieExpiresAfterDays: 365,
+
+  // You can change to cookie domain for the consent manager itself.
+  // Use this if you want to get consent once for multiple matching domains.
+  // If undefined, Klaro will use the current domain.
+  //cookieDomain: '.github.com',
+
+  // You can change to cookie path for the consent manager itself.
+  // Use this to restrict the cookie visibility to a specific path.
+  // If undefined, Klaro will use '/' as cookie path.
+  //cookiePath: '/',
+
+  // Defines the default state for services (true=enabled by default).
+  default: false,
+
+  // If "mustConsent" is set to true, Klaro will directly display the consent
+  // manager modal and not allow the user to close it before having actively
+  // consented or declines the use of third-party services.
+  mustConsent: false,
+
+  // Show "accept all" to accept all services instead of "ok" that only accepts
+  // required and "default: true" services
   acceptAll: true,
-  translations: {},
+
+  // replace "decline" with cookie manager modal
+  hideDeclineAll: false,
+
+  // hide "learnMore" link
+  hideLearnMore: false,
+
+  // show cookie notice as modal
+  noticeAsModal: false,
+
+  translations: {
+    en: {
+      privacyPolicyUrl: '/privacy',
+      consentModal: {
+        title: 'We value your privacy',
+        description:
+          'We use cookies and third-party services to enhance your experience. You can choose which services you consent to.',
+      },
+      privacyPolicy: {
+        name: 'privacy policy',
+        text: 'To learn more, please read our {privacyPolicy}.',
+      },
+      consentNotice: {
+        title: 'Cookie Consent',
+        description: 'We use cookies to improve your experience. You can manage your preferences.',
+        learnMore: 'Learn more',
+      },
+      purposes: {
+        analytics: 'Analytics',
+        security: 'Security',
+        essential: 'Essential',
+        marketing: 'Marketing',
+      },
+    },
+    ko: {
+      privacyPolicyUrl: '/privacy',
+      consentModal: {
+        title: '귀하의 개인정보를 소중하게 생각합니다',
+        description:
+          '저희는 귀하의 경험을 향상시키기 위해 쿠키와 제3자 서비스를 사용합니다. 동의할 서비스를 직접 선택하실 수 있습니다.',
+      },
+      privacyPolicy: {
+        name: '개인정보 처리방침',
+        text: '자세한 내용은 저희 {privacyPolicy}를 확인해 주세요.',
+      },
+      consentNotice: {
+        title: '쿠키 동의',
+        description: '저희는 귀하의 경험을 개선하기 위해 쿠키를 사용합니다. 환경설정을 관리하실 수 있습니다.',
+        learnMore: '자세히 알아보기',
+      },
+      purposes: {
+        analytics: '분석',
+        security: '보안',
+        essential: '필수',
+        marketing: '마케팅',
+      },
+      purposeItem: {
+        service: '서비스',
+      },
+      service: {
+        purpose: '목적',
+      },
+      decline: '거부',
+      ok: '동의',
+      acceptSelected: '선택 동의',
+      acceptAll: '모두 동의',
+      poweredBy: 'Realized with Klaro!',
+    },
+  },
+
+  // This is a list of third-party services that Klaro will manage for you.
   services: [
     {
-      name: 'google-tag-manager',
-      required: true,
-      purposes: ['marketing', 'functional'],
-      manages: ['google-analytics', 'google-ads', 'google-ad-user-data', 'google-ad-personalization'],
-      onAccept: `
-        // Notify GTM about all services that were accepted.
-        for(let k of Object.keys(opts.consents)){
-            if (opts.consents[k]){
-                let eventName = 'klaro-'+k+'-accepted'
-                dataLayer.push({'event': eventName})
-            }
-        }
-        // Enable consented storage types
-        if (opts.consents['google-analytics']){
-            gtag('consent', 'update', {'analytics_storage': 'granted'})
-        }
-        else{
-            gtag('consent', 'update', {'analytics_storage': 'denied'})
-        }
-        if (opts.consents['google-ads']){
-            gtag('consent', 'update', {'ad_storage': 'granted'})
-        }
-        else{
-            gtag('consent', 'update', {'ad_storage': 'denied'})
-        }
-        if (opts.consents['google-ad-user-data']){
-            gtag('consent', 'update', {'ad_user_data': 'granted'})
-        }
-        else{
-            gtag('consent', 'update', {'ad_user_data': 'denied'})
-        }
-        if (opts.consents['google-ad-personalization']){
-            gtag('consent', 'update', {'ad_personalization': 'granted'})
-        }
-        else{
-            gtag('consent', 'update', {'ad_personalization': 'denied'})
-        }
-      `,
-      onInit: `
-        window.dataLayer = window.dataLayer || [];
-        window.gtag = function(){dataLayer.push(arguments)}
-        gtag('consent', 'default', {
-          'ad_storage': 'denied',
-          'analytics_storage': 'denied',
-          'ad_user_data': 'denied',
-          'ad_personalization': 'denied'
-        })
-        gtag('set', 'ads_data_redaction', true)
-      `,
-      onDecline: `
-        window.dataLayer = window.dataLayer || [];
-        window.gtag = function(){dataLayer.push(arguments)}
-        gtag('consent', 'default', {
-          'ad_storage': 'denied',
-          'analytics_storage': 'denied',
-          'ad_user_data': 'denied',
-          'ad_personalization': 'denied'
-        })
-        gtag('set', 'ads_data_redaction', true)
-      `,
-    },
-    {
+      // Each service should have a unique (and short) name.
       name: 'google-analytics',
-      purposes: ['marketing'],
-    },
-    {
-      name: 'google-ads',
-      purposes: ['marketing'],
-    },
-    {
-      name: 'google-ad-user-data',
-      purposes: ['marketing'],
-    },
-    {
-      name: 'google-ad-personalization',
-      purposes: ['marketing'],
+
+      // If "default" is set to true, the service will be enabled by default
+      // Overwrites global "default" setting.
+      // We recommend leaving this to "false" for services that collect
+      // personal information.
+      default: true,
+
+      // The title of your service as listed in the consent modal.
+      title: 'Google Analytics',
+
+      // The purpose(s) of this service. Will be listed on the consent notice.
+      // Do not forget to add translations for all purposes you list here.
+      purposes: ['analytics'],
+
+      // A list of regex expressions or strings giving the names of
+      // cookies set by this service. If the user withdraws consent for a
+      // given service, Klaro will then automatically delete all matching
+      // cookies.
+      cookies: [/^_ga/, /^_gid/, /^_gat/],
+
+      // If "required" is set to true, Klaro will not allow this service to
+      // be disabled by the user.
+      required: false,
+
+      // If "optOut" is set to true, Klaro will load this service even before
+      // the user gave explicit consent.
+      // We recommend always leaving this "false".
+      optOut: false,
+
+      // If "onlyOnce" is set to true, the service will only be executed
+      // once regardless how often the user toggles it on and off.
+      onlyOnce: true,
+      callback: function (consent, service) {
+        window.dataLayer = window.dataLayer || [];
+        window.gtag = function () {
+          dataLayer.push(arguments);
+        };
+
+        if (consent) {
+          gtag('consent', 'update', {
+            ad_storage: 'granted',
+            analytics_storage: 'granted',
+            ad_user_data: 'granted',
+            ad_personalization: 'granted',
+          });
+        } else {
+          gtag('consent', 'update', {
+            ad_storage: 'denied',
+            analytics_storage: 'denied',
+            ad_user_data: 'denied',
+            ad_personalization: 'denied',
+          });
+        }
+      },
     },
   ],
 };

--- a/public/consent_config.js
+++ b/public/consent_config.js
@@ -1,0 +1,84 @@
+var klaroConfig = {
+  acceptAll: true,
+  translations: {},
+  services: [
+    {
+      name: 'google-tag-manager',
+      required: true,
+      purposes: ['marketing', 'functional'],
+      manages: ['google-analytics', 'google-ads', 'google-ad-user-data', 'google-ad-personalization'],
+      onAccept: `
+        // Notify GTM about all services that were accepted.
+        for(let k of Object.keys(opts.consents)){
+            if (opts.consents[k]){
+                let eventName = 'klaro-'+k+'-accepted'
+                dataLayer.push({'event': eventName})
+            }
+        }
+        // Enable consented storage types
+        if (opts.consents['google-analytics']){
+            gtag('consent', 'update', {'analytics_storage': 'granted'})
+        }
+        else{
+            gtag('consent', 'update', {'analytics_storage': 'denied'})
+        }
+        if (opts.consents['google-ads']){
+            gtag('consent', 'update', {'ad_storage': 'granted'})
+        }
+        else{
+            gtag('consent', 'update', {'ad_storage': 'denied'})
+        }
+        if (opts.consents['google-ad-user-data']){
+            gtag('consent', 'update', {'ad_user_data': 'granted'})
+        }
+        else{
+            gtag('consent', 'update', {'ad_user_data': 'denied'})
+        }
+        if (opts.consents['google-ad-personalization']){
+            gtag('consent', 'update', {'ad_personalization': 'granted'})
+        }
+        else{
+            gtag('consent', 'update', {'ad_personalization': 'denied'})
+        }
+      `,
+      onInit: `
+        window.dataLayer = window.dataLayer || [];
+        window.gtag = function(){dataLayer.push(arguments)}
+        gtag('consent', 'default', {
+          'ad_storage': 'denied',
+          'analytics_storage': 'denied',
+          'ad_user_data': 'denied',
+          'ad_personalization': 'denied'
+        })
+        gtag('set', 'ads_data_redaction', true)
+      `,
+      onDecline: `
+        window.dataLayer = window.dataLayer || [];
+        window.gtag = function(){dataLayer.push(arguments)}
+        gtag('consent', 'default', {
+          'ad_storage': 'denied',
+          'analytics_storage': 'denied',
+          'ad_user_data': 'denied',
+          'ad_personalization': 'denied'
+        })
+        gtag('set', 'ads_data_redaction', true)
+      `,
+    },
+    {
+      name: 'google-analytics',
+      purposes: ['marketing'],
+    },
+    {
+      name: 'google-ads',
+      purposes: ['marketing'],
+    },
+    {
+      name: 'google-ad-user-data',
+      purposes: ['marketing'],
+    },
+    {
+      name: 'google-ad-personalization',
+      purposes: ['marketing'],
+    },
+  ],
+};

--- a/public/consent_config.js
+++ b/public/consent_config.js
@@ -174,7 +174,10 @@ var klaroConfig = {
       // cookies set by this service. If the user withdraws consent for a
       // given service, Klaro will then automatically delete all matching
       // cookies.
-      cookies: [/^_ga/, /^_gid/, /^_gat/],
+      cookies: [
+        /^_ga/, // Universal Analytics & GA4
+        /^_ga_[\w]+/, // GA4 (e.g., _ga_XXXXXXXXXX)
+      ],
 
       // If "required" is set to true, Klaro will not allow this service to
       // be disabled by the user.
@@ -188,6 +191,7 @@ var klaroConfig = {
       // If "onlyOnce" is set to true, the service will only be executed
       // once regardless how often the user toggles it on and off.
       onlyOnce: true,
+
       callback: function (consent, service) {
         window.dataLayer = window.dataLayer || [];
         window.gtag = function () {
@@ -198,13 +202,6 @@ var klaroConfig = {
           gtag('consent', 'update', {
             ad_storage: 'granted',
             analytics_storage: 'granted',
-            ad_user_data: 'granted',
-            ad_personalization: 'granted',
-          });
-        } else {
-          gtag('consent', 'update', {
-            ad_storage: 'denied',
-            analytics_storage: 'denied',
             ad_user_data: 'denied',
             ad_personalization: 'denied',
           });

--- a/src/components/common/Analytics.astro
+++ b/src/components/common/Analytics.astro
@@ -1,13 +1,34 @@
 ---
-import { GoogleAnalytics } from '@astrolib/analytics';
 import { ANALYTICS } from 'astrowind:config';
+
+const gaId = ANALYTICS?.vendors?.googleAnalytics?.id;
+const partytown = ANALYTICS?.vendors?.googleAnalytics?.partytown;
+const attrs = partytown ? { type: 'text/partytown' } : {};
 ---
 
 {
-  ANALYTICS?.vendors?.googleAnalytics?.id ? (
-    <GoogleAnalytics
-      id={String(ANALYTICS.vendors.googleAnalytics.id)}
-      partytown={ANALYTICS?.vendors?.googleAnalytics?.partytown}
-    />
+  gaId ? (
+    <>
+      <script
+        is:inline
+        type="text/plain"
+        data-type="text/javascript"
+        data-name="google-analytics"
+        async
+        src={`https://www.googletagmanager.com/gtag/js?id=${gaId}`}
+        {...attrs}
+      />
+      <script
+        is:inline
+        type="text/plain"
+        data-type="text/javascript"
+        data-name="google-analytics"
+        define:vars={{ gaId }}
+        {...attrs}
+      >
+        window.dataLayer = window.dataLayer || []; function gtag() {window.dataLayer.push(arguments)}
+        gtag("js", new Date()); gtag("config", gaId);
+      </script>
+    </>
   ) : null
 }

--- a/src/components/common/CMP.astro
+++ b/src/components/common/CMP.astro
@@ -1,0 +1,7 @@
+---
+
+---
+
+<!-- make sure the config gets loaded before Klaro -->
+<script defer type="text/javascript" src="consent_config.js"></script>
+<script defer type="text/javascript" src="https://cdn.kiprotect.com/klaro/v0.7.22/klaro.js"></script>

--- a/src/components/common/CMP.astro
+++ b/src/components/common/CMP.astro
@@ -5,3 +5,10 @@
 <!-- make sure the config gets loaded before Klaro -->
 <script defer type="text/javascript" src="consent_config.js"></script>
 <script defer type="text/javascript" src="https://cdn.kiprotect.com/klaro/v0.7.22/klaro.js"></script>
+
+<style>
+:global(.cm-powered-by) {
+  display: none !important;
+}
+</style>
+

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -9,6 +9,7 @@ import CustomStyles from '~/components/CustomStyles.astro';
 import ApplyColorMode from '~/components/common/ApplyColorMode.astro';
 import Metadata from '~/components/common/Metadata.astro';
 import SiteVerification from '~/components/common/SiteVerification.astro';
+import CMP from '~/components/common/CMP.astro';
 import Analytics from '~/components/common/Analytics.astro';
 import BasicScripts from '~/components/common/BasicScripts.astro';
 
@@ -34,6 +35,7 @@ const { language, textDirection } = I18N;
     <ApplyColorMode />
     <Metadata {...metadata} />
     <SiteVerification />
+    <CMP />
     <Analytics />
 
     <!-- Comment the line below to disable View Transitions -->


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

content manager가 없어서 GA에서 기본 content 상태만 적용 가능

Issue Number: close #6 


## What is the new behavior?
content manager 추가

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
en
<img src="https://github.com/user-attachments/assets/1b6439e9-5ccd-4ad3-86b6-cb24ac3c4eab" width=400 />
<img src="https://github.com/user-attachments/assets/efa0f5d0-522e-40af-be71-be29d32ee35f" width=400 />
<img src="https://github.com/user-attachments/assets/bc2187e7-4153-443e-b76c-6f45d8866e48" width=400 />

ko
<img src="https://github.com/user-attachments/assets/2e337fb2-14bf-4b95-930f-b87a78c0156d" width=400 />
<img src="https://github.com/user-attachments/assets/0a838f02-b418-4381-b4ab-57aab7d34f35" width=400 />


### 언어 변경
```
klaro.defaultConfig.lang='ko'
klaro.show()
```


### Known issues

- 동의/거절하지 않은 상태로 페이지 이동 시 동의 배너 사라짐
  - 새로고침 시 재등장
- consent default 지정 안됨 문제
  - [klaro 설정 예제](https://github.com/kiprotect/klaro/blob/master/dist/examples/gtm-config.js)를 그대로 따라 했지만 `onInit`에서 default 설정하는 부분이 GA init보다 늦게 실행되어 default값이 GA에서 설정한 값으로 지정됨
  - GA에서 설정한 값을 overwrite하고 싶으면 `default`가 아닌 `update`를 사용하는 방법이 있지만 GA에서 설정하는 것도 무방할 것으로 보여 일단 유지
- 동의 항목
  - 동의 항목을 최대로 가지고 왔지만 corp web에서는 GA 동의만 받아도 무방함. 나머지는 템플릿 느낌도 있는데 필요없어보이면 리뷰 주세요.

